### PR TITLE
Fixed Small Bug in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,15 @@ Folder [12-proximity-measurement](./12-proximity-measurement):
 
 PEPP-PT is preparing a number of source code repositories to be open sourced.
 
-These repositories include:
+These repositories contain the complete and comprehensive code (including full documentation and code for testing) and configurations of all backends, frontends, apps, applications, administrator frontends and other tools, such as:
 
 * Backend services
 * Android application core libraries
 * Android application reference implementation
 * iOS application core libraries
 * iOS application reference implementation
+
+We will release the code under such an [OSI certified](https://opensource.org/licenses) open source license that requires disclosure of the code of derived works, like the [European Union Public License](https://de.wikipedia.org/wiki/European_Union_Public_Licence) (EUPL) or [GNU General Public License](https://de.wikipedia.org/wiki/GNU_General_Public_License) (GPL).
 
 Our goal when open sourcing the code is to be transparent and establish
 a dialog with the community.  Through this transparency and ongoing discussion,


### PR DESCRIPTION
I fixed a small bug in the Readme.md about the release of the code. The new version explains this in more detail.
In addition, I have added a clarification of the licenses, which ensures that the code of derived works must also be released. Since the European Union Public License is available in all official languages of the European Union, this is the preferred option.